### PR TITLE
ResourceAudioEffectsTestSuite: Expanded list of effects & more asserts

### DIFF
--- a/projects/xUnit/scripts/ResourceAudioEffectsTestSuite/ResourceAudioEffectsTestSuite.gml
+++ b/projects/xUnit/scripts/ResourceAudioEffectsTestSuite/ResourceAudioEffectsTestSuite.gml
@@ -22,7 +22,13 @@ function ResourceAudioEffectsTestSuite() : TestSuite() constructor {
 			audio_effect_create(AudioEffectType.Gain), 
 			audio_effect_create(AudioEffectType.HPF2),
 			audio_effect_create(AudioEffectType.LPF2), 
-			audio_effect_create(AudioEffectType.Reverb1)
+			audio_effect_create(AudioEffectType.Reverb1),
+			audio_effect_create(AudioEffectType.Tremolo),
+			audio_effect_create(AudioEffectType.EQ),
+			audio_effect_create(AudioEffectType.PeakEQ),
+			audio_effect_create(AudioEffectType.HiShelf),
+			audio_effect_create(AudioEffectType.LoShelf),
+			audio_effect_create(AudioEffectType.Compressor)
 		];
 		
 		array_foreach(_effects, function(_value, _index) {
@@ -47,6 +53,9 @@ function ResourceAudioEffectsTestSuite() : TestSuite() constructor {
 					assert_true(variable_struct_exists(_value, "gain"));
 					break;
 				case AudioEffectType.HPF2:
+					assert_true(variable_struct_exists(_value, "cutoff"));
+					assert_true(variable_struct_exists(_value, "q"));
+					break;
 				case AudioEffectType.LPF2:
 					assert_true(variable_struct_exists(_value, "cutoff"));
 					assert_true(variable_struct_exists(_value, "q"));
@@ -55,6 +64,45 @@ function ResourceAudioEffectsTestSuite() : TestSuite() constructor {
 					assert_true(variable_struct_exists(_value, "size"));
 					assert_true(variable_struct_exists(_value, "damp"));
 					assert_true(variable_struct_exists(_value, "mix"));
+					break;
+				case AudioEffectType.Tremolo:
+					assert_true(variable_struct_exists(_value, "rate"));
+					assert_true(variable_struct_exists(_value, "intensity"));
+					assert_true(variable_struct_exists(_value, "offset"));
+					assert_true(variable_struct_exists(_value, "shape"));
+					break;
+				case AudioEffectType.EQ:
+					assert_true(variable_struct_exists(_value, "locut"));
+					assert_true(variable_struct_exists(_value, "loshelf"));
+					assert_true(variable_struct_exists(_value, "eq1"));
+					assert_true(variable_struct_exists(_value, "eq2"));
+					assert_true(variable_struct_exists(_value, "eq3"));
+					assert_true(variable_struct_exists(_value, "eq4"));
+					assert_true(variable_struct_exists(_value, "hishelf"));
+					assert_true(variable_struct_exists(_value, "hicut"));
+					break;
+				case AudioEffectType.PeakEQ:
+					assert_true(variable_struct_exists(_value, "freq"));
+					assert_true(variable_struct_exists(_value, "q"));
+					assert_true(variable_struct_exists(_value, "gain"));
+					break;
+				case AudioEffectType.HiShelf:
+					assert_true(variable_struct_exists(_value, "freq"));
+					assert_true(variable_struct_exists(_value, "q"));
+					assert_true(variable_struct_exists(_value, "gain"));
+					break;
+				case AudioEffectType.LoShelf:
+					assert_true(variable_struct_exists(_value, "freq"));
+					assert_true(variable_struct_exists(_value, "q"));
+					assert_true(variable_struct_exists(_value, "gain"));
+					break;
+				case AudioEffectType.Compressor:
+					assert_true(variable_struct_exists(_value, "ingain"));
+					assert_true(variable_struct_exists(_value, "threshold"));
+					assert_true(variable_struct_exists(_value, "ratio"));
+					assert_true(variable_struct_exists(_value, "attack"));
+					assert_true(variable_struct_exists(_value, "release"));
+					assert_true(variable_struct_exists(_value, "outgain"));
 					break;
 				default:
 					throw "Error: Unknown audio effect type";
@@ -96,9 +144,20 @@ function ResourceAudioEffectsTestSuite() : TestSuite() constructor {
 		// Verify that the retrieved bus is the same as the one we linked each emitter to
 		for (var _i = 0; _i < array_length(_buses); ++_i)
 			assert_equals(_buses[_i], audio_emitter_get_bus(_emitters[_i]));
+		
+		// Verify that the retrieved emitter is the same one as the one we linked to the bus
+		for (var _i = 0; _i < array_length(_emitters); _i++)
+			assert_equals(_emitters[_i], audio_bus_get_emitters(_buses[_i])[0]);
+			
+		// Clear emitters from each bus and verify the emitters are relinked to the main bus
+		for (var _i = 0; _i < array_length(_buses); _i++)
+			audio_bus_clear_emitters(_buses[_i]);
+		// All 4 emitters should be linked to the main bus now
+		assert_equals(array_length(audio_bus_get_emitters(audio_bus_main)), 4);
 			
 		// Clean up the emitters
 		for (var _i = 0; _i < array_length(_emitters); ++_i)
 			audio_emitter_free(_emitters[_i]);
+			
 	});
 }


### PR DESCRIPTION
Expanded list of effects that test their variables now include: -Tremolo
- EQ
- PeakEQ
- HiShelf
- LoShelf
- Compressor

Created asserts for:
- verifying that emitters are being correctly linked to audio buses
- verifying that clearing emitters on a bus correctly relinks them to the main bus