### PR TITLE
Bug: audio emitter does not get freed in BasicAudioTestSuite, which causes issues in later test suite

### DIFF
--- a/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
+++ b/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
@@ -201,6 +201,8 @@ function BasicAudioTestSuite() : TestSuite() constructor {
 			assert_true(isPlaying, "#8.2." + string(i) + " audio should be playing");
 			audio_stop_sound(i);
 			
+			audio_emitter_free(audioEmitter);
+			
 			//#3
 			var _sound_params =
 			{

--- a/projects/xUnit/xUnit.yyp
+++ b/projects/xUnit/xUnit.yyp
@@ -49,7 +49,6 @@
     {"$GMFolder":"","%Name":"Utils","folderPath":"folders/Tests/Utils.yy","name":"Utils","resourceType":"GMFolder","resourceVersion":"2.0",},
   ],
   "IncludedFiles":[
-    {"$GMIncludedFile":"","%Name":"config.json","CopyToMask":-1,"filePath":"datafiles","name":"config.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"drawTilemapTestExpected.png","CopyToMask":-1,"filePath":"datafiles","name":"drawTilemapTestExpected.png","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"drawTilemapTestExpectedBuffer","CopyToMask":-1,"filePath":"datafiles","name":"drawTilemapTestExpectedBuffer","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"drawTileTestExpected.png","CopyToMask":-1,"filePath":"datafiles","name":"drawTileTestExpected.png","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
@@ -61,7 +60,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2024.600.0.585",
+    "IDEVersion":"2024.800.0.586",
   },
   "name":"xUnit",
   "resources":[


### PR DESCRIPTION
Audio emitter created in BasicAudioTestFrameWork now gets freed after the test ends