### PR TITLE
Fixes #121 - Refactored BasicScriptTestSuite

### DIFF
--- a/projects/xUnit/scripts/BasicScriptTestSuite/BasicScriptTestSuite.gml
+++ b/projects/xUnit/scripts/BasicScriptTestSuite/BasicScriptTestSuite.gml
@@ -1,28 +1,47 @@
+/// @function addArguments()
+/// @description This function will add together all arguments passed into it and return the result
+/// @returns {Real}
+function addArguments() 
+{
+    var _result = 0;
+    
+    for (var _n = argument_count - 1; _n>=0; --_n) {
+        _result += argument[_n];
+    }
+    return _result;
+}
 
 function BasicScriptTestSuite() : TestSuite() constructor {
 
-	addFact("script_execute_ext_test", function() {
-
-		function addArguments()
-		{
-			var _result = 0;
-			
-			for (var _n = argument_count - 1; _n>=0; --_n) {
-				_result += argument[_n];
-			}
-			return _result;
-		}
+	addFact("script_execute_ext_test #1", function() {
 			
 		var _array = [ 10, 20, 30, 40, 50, 60];
+        
+        // Execute addArguments and check that it correctly sums the inputted array
 		var _result = script_execute_ext(addArguments, _array);
-		assert_equals( _result, 210, "#1.0 - test basic script_execute_ext");
-		
-		_result = script_execute_ext(addArguments, _array, 2);
-		assert_equals( _result, 180, "#1.1 - test basic script_execute_ext with offset");
-		
-		_result = script_execute_ext(addArguments, _array, 2, 2);
-		assert_equals( _result, 70, "#1.2 - test basic script_execute_ext with offset and count");
-	})
+		assert_equals( _result, 210, "test basic script_execute_ext");
+        
+	});
+    
+    addFact("script_execute_ext_test #2", function() {
+        
+        var _array = [ 10, 20, 30, 40, 50, 60];
+        
+        // Execute addArguments and check that it correctly sums the inputted array with an offset of 2
+        var _result = script_execute_ext(addArguments, _array, 2);
+        assert_equals( _result, 180, "test basic script_execute_ext with offset");
+        
+    });
+    
+    addFact("script_execute_ext_test #3", function() {
+        
+        var _array = [ 10, 20, 30, 40, 50, 60];
+        
+        // Execute addArguments and check that it correctly sums the inputted array with an offset and count of 2
+        var _result = script_execute_ext(addArguments, _array, 2, 2);
+        assert_equals( _result, 70, "test basic script_execute_ext with offset and count");
+        
+    });
 	
 }
 


### PR DESCRIPTION
Split `script_execute_ext_test` from BasicScriptTestSuite into 3 more specific facts:
 - `script_execute_ext_test #1`
 - `script_execute_ext_test #2`
 - `script_execute_ext_test #3`

Also added comments, put repeated code into a function, and modified assert descriptions.