### PR TITLE
Audio test tweaks

### DIFF
--- a/projects/xUnit/objects/objRunner/Create_0.gml
+++ b/projects/xUnit/objects/objRunner/Create_0.gml
@@ -39,13 +39,13 @@ testFramework.addSuite(BasicSurfaceTestSuite);
 testFramework.addSuite(BasicTilemapTestSuite);
 testFramework.addSuite(BasicVariableTestSuite);
 testFramework.addSuite(BasicWeakRefsTestSuite);
-testFramework.addSuite(ResourceAudioBuffersTestSuite); /* needs fix */
+testFramework.addSuite(ResourceAudioBuffersTestSuite);
 testFramework.addSuite(ResourceAudioEffectsTestSuite);
 testFramework.addSuite(ResourceAudioEmittersTestSuite);
 testFramework.addSuite(ResourceAudioGroupsTestSuite);
 testFramework.addSuite(ResourceAudioListenersTestSuite);
 testFramework.addSuite(ResourceAudioLoopPointsTestSuite);
-testFramework.addSuite(ResourceAudioSynchronisationTestSuite); /* needs fix */
+testFramework.addSuite(ResourceAudioSynchronisationTestSuite);
 testFramework.addSuite(ResourceCameraTestSuite);
 testFramework.addSuite(ResourceEventsTestSuite);
 testFramework.addSuite(ResourceLayersTestSuite);

--- a/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
+++ b/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
@@ -875,7 +875,7 @@ function BasicAudioTestSuite() : TestSuite() constructor {
 		
 		ev_create: function() {
 			// play audio
-			sound = audio_play_sound(snd_coinpickup_OGG, 1, false);
+			sound = audio_play_sound(snd_compressed, 1, false);
 			// start a timer
 			startTime = get_timer() / 1000000; // microseconds --> seconds
 			

--- a/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
+++ b/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
@@ -920,12 +920,15 @@ function BasicAudioTestSuite() : TestSuite() constructor {
 		},
 		
 		ev_async_audio_playback_ended: function() {
+            if (async_load[? "sound_id"] != sound) {
+                return;
+            }
+            
 			// when 'playback ended' is triggered, check if audio has stopped playing
 			var isPlaying = audio_is_playing(sound);
 			assert_false(isPlaying, "ev_async_audio_playback_ended should trigger when a sound has stopped playing");
 			
 			test_end();
-			
 		},
 		
 	});

--- a/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
+++ b/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
@@ -845,8 +845,8 @@ function BasicAudioTestSuite() : TestSuite() constructor {
 		
 		ev_create: function() {
 			// play sound at full gain then decrease to 0 over 0.5 seconds
-			sound = audio_play_sound(snd_coinpickup_OGG, 1, false);
-			audio_sound_gain(sound, 0, 500);
+			sound = audio_play_sound(snd_coinpickup_OGG, 1, false, 1);
+			audio_sound_gain(sound, 0, 100);
 			
 			startTime = get_timer() / 1000000; // microseconds --> seconds
 		},
@@ -855,7 +855,7 @@ function BasicAudioTestSuite() : TestSuite() constructor {
 			// finish test when 0.6 second has passed (to give some leeway)
 			var timeSpent = (get_timer() / 1000000) - startTime; // in seconds
 
-			if (timeSpent > 0.6){
+			if (timeSpent > 0.5) {
 				
 				// check if audio gain has decreased over time
 				var gain = audio_sound_get_gain(sound);

--- a/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
+++ b/projects/xUnit/scripts/BasicAudioTestSuite/BasicAudioTestSuite.gml
@@ -896,15 +896,11 @@ function BasicAudioTestSuite() : TestSuite() constructor {
 			
 			var timeSpent = (get_timer() / 1000000) - startTime; // in seconds
 			
-			// after 0.25 seconds, check if track position is correct
-			if (timeSpent >= 0.25) {
-				
+			// after 0.5 seconds, check if track position is non-zero
+			if (timeSpent >= 0.5) {
 				var trackPos = audio_sound_get_track_position(sound);
-				// need to give some leeway to the asserts here,
-				// due to how often ev_step occurs, it might not check
-				// exactly at 0.25 seconds
-				assert_less_or_equal(trackPos, 0.27, "audio_sound_get_track_position should return ~0.25");
-				assert_greater_or_equal(trackPos, 0.24, "audio_sound_get_track_position should return ~0.25");
+
+				assert_greater(trackPos, 0, "audio_sound_get_track_position should be non-zero");
 				
 				audio_stop_sound(sound);
 				

--- a/projects/xUnit/scripts/ResourceAudioEffectsTestSuite/ResourceAudioEffectsTestSuite.gml
+++ b/projects/xUnit/scripts/ResourceAudioEffectsTestSuite/ResourceAudioEffectsTestSuite.gml
@@ -262,7 +262,7 @@ function ResourceAudioEffectsTestSuite() : TestSuite() constructor {
 			audio_emitter_bus(_emitters[_i], _buses[_i]);
 			
 		// Clear emitters from each bus and verify the emitters are relinked to the main bus
-		for (var _i = 0; _i < array_length(_buses); _i++)
+		for (var _i = 1; _i < array_length(_buses); _i++)
 			audio_bus_clear_emitters(_buses[_i]);
 		// All 4 emitters should be linked to the main bus now
 		assert_equals(array_length(audio_bus_get_emitters(audio_bus_main)), 4);

--- a/projects/xUnit/scripts/ResourceAudioGroupsTestSuite/ResourceAudioGroupsTestSuite.gml
+++ b/projects/xUnit/scripts/ResourceAudioGroupsTestSuite/ResourceAudioGroupsTestSuite.gml
@@ -22,7 +22,7 @@ function getAudioGroups() {
 	
 function ResourceAudioGroupsTestSuite() : TestSuite() constructor {
 	
-	addFact("Default audio group test #1", function() { // Known issue https://github.com/YoYoGames/GameMaker-Bugs/issues/7371
+	addFact("Default audio group test #1", function() {
 		
 		var loaded = audio_group_is_loaded(audiogroup_default);
 		assert_true(loaded, "Default audiogroup should be loaded by default");

--- a/projects/xUnit/scripts/ResourceAudioLoopPointsTestSuite/ResourceAudioLoopPointsTestSuite.gml
+++ b/projects/xUnit/scripts/ResourceAudioLoopPointsTestSuite/ResourceAudioLoopPointsTestSuite.gml
@@ -47,42 +47,38 @@ function ResourceAudioLoopPointsTestSuite() : TestSuite() constructor {
 	addTestAsync("Audio track position with loop points", objTestAsync, {
 		
 		ev_create: function() {
-			
-			// Create loop points between 0 and 1 seconds, then play the audio
-			audio_sound_loop_start(snd_compressed, 0);
-			audio_sound_loop_end(snd_compressed, 1);
+			loop_start = 0.1
+            loop_end = 0.2
+            
+			// Create loop points, then play the audio
+			audio_sound_loop_start(snd_compressed, loop_start);
+			audio_sound_loop_end(snd_compressed, loop_end);
 			
 			sound = audio_play_sound(snd_compressed, 1, true);
 			
 			startTime = get_timer() / 1000000; // microseconds --> seconds
-			
 		},
 		
 		ev_step: function() {
 			
 			var timeSpent = (get_timer() / 1000000) - startTime; // in seconds
 			
-			// After 1.5 seconds, the audio should have looped back,
-			// and should now be at 0.5 seconds
-			if (timeSpent >= 1.5) {
+			// After 1 second, the audio should be somewhere in the loop section
+			if (timeSpent >= 1) {
 				
 				var trackPos = audio_sound_get_track_position(sound);
 				
-				assert_less_or_equal(trackPos, 0.55, "Track position should loop back when audio loop is enabled");
-				assert_greater_or_equal(trackPos, 0.45, "Track position should loop back when audio loop is enabled");
+				assert_less_or_equal(trackPos, loop_end, "Track position is not in the loop section");
+				assert_greater_or_equal(trackPos, loop_start, "Track position is not in the loop section");
 				
 				test_end();
-				
 			}
 			
 		},
 		
 		ev_cleanup: function() {
-			
 			audio_stop_all();
-			
 		}
-		
 	});
 	
 }

--- a/projects/xUnit/scripts/ResourceAudioSynchronisationTestSuite/ResourceAudioSynchronisationTestSuite.gml
+++ b/projects/xUnit/scripts/ResourceAudioSynchronisationTestSuite/ResourceAudioSynchronisationTestSuite.gml
@@ -177,14 +177,11 @@ function ResourceAudioSynchronisationTestSuite() : TestSuite() constructor {
 		
 			var timeSpent = (get_timer() / 1000000) - startTime; // in seconds
 			
-			if (timeSpent >= 0.25) {
+			if (timeSpent >= 0.5) {
 				
 				var trackPos = audio_sync_group_get_track_pos(syncGroup);
-				// need to give some leeway to the asserts here,
-				// due to how often ev_step occurs, it might not check
-				// exactly at 0.25 seconds
-				assert_less_or_equal(trackPos, 0.27, "audio_sync_group_get_track_pos should correctly return track position (~0.25)");
-				assert_greater_or_equal(trackPos, 0.24, "audio_sync_group_get_track_pos should correctly return track position (~0.25)");
+                
+				assert_greater(trackPos, 0, "audio_sync_group_get_track_pos should have a non-zero track position");
 				
 				audio_stop_sync_group(syncGroup);
 				


### PR DESCRIPTION
- Added some leeway in gain-over-time test to account for the value being updated once per audio tick.
- Removed assumptions of track position based on the call time of a playback function, as playback starts asynchronously.
- Used a sound with a longer duration for the track-position-over-time test, as the previous sound was barely longer than the intended duration of the test.
- Added a check in the end-of-playback-event test that the event fired is for the sound being tested.
- Prevented an attempt to clear emitters from `audio_bus_main`, as this is not allowed.
- Changed the looping test to assert that the track position is somewhere within the loop bounds after a given time.