### PR TITLE
`min` assertion expecting incorrect value

### DIFF
--- a/projects/xUnit/scripts/BasicMathTestSuite/BasicMathTestSuite.gml
+++ b/projects/xUnit/scripts/BasicMathTestSuite/BasicMathTestSuite.gml
@@ -3125,7 +3125,7 @@ function BasicMathTestSuite() : TestSuite() constructor {
 			
 		//#20 min( int64 const , int64 const , int64 const , int64 const )
 		_result = min(0x1122334455667788, 0x8877665544332211, 0x7FFFFFFFFFFFFFFF, 0x5566778811223344);
-		assert_equals(_result, 0x1122334455667788, "#20 min( int64 const , int64 const , int64 const , int64 const )");
+		assert_equals(_result, 0x8877665544332211, "#20 min( int64 const , int64 const , int64 const , int64 const )");
 			
 		//#21 min( real const , real const , real const , real const )
 		_result = min(kReal_MinTest, _objOther.oReal, global.gReal, _vReal);


### PR DESCRIPTION
The original expected value `0x1122334455667788` compiles as `1234605616436508552` where as the correct minimum value `0x8877665544332211` compiles as `-8613303245920329199`

If this is an error and we are not expecting a decimal from signed 2's complacence from compile time then this should be issued over on the bug reporter.