### PR TITLE
Removed not planned syntax crashing test case

### DIFF
--- a/projects/xUnit/scripts/BasicUnaryUpdateExpressions/BasicUnaryUpdateExpressions.gml
+++ b/projects/xUnit/scripts/BasicUnaryUpdateExpressions/BasicUnaryUpdateExpressions.gml
@@ -203,20 +203,4 @@ function BasicUnaryUpdateExpressions() : TestSuite() constructor {
 		assert_equals(score  , 0, "Static variable get failed.");
     });
 	
-	addFact("Function Call Unary Update", function() {
-		
-		assert_true(false, "This code should be uncommented when the bug #9040 is fixed!");
-		
-		////////////////////////////////////////////////////////////////////////////////////////////////////
-		//var _func = function(){ return 0 }
-		//
-		//assert_equals(_func()  , 0, "Function call get failed.");
-		//assert_equals(++_func(), 0, "Function call PlusPlus Suffix failed.");
-		//assert_equals(_func()++, 2, "Function call PlusPlus Prefix failed.");
-		//assert_equals(--_func(), 2, "Function call MinusMinus Suffix failed.");
-		//assert_equals(_func()--, 0, "Function call MinusMinus Prefix failed.");
-		//assert_equals(_func()  , 0, "Function call get failed.");
-		////////////////////////////////////////////////////////////////////////////////////////////////////
-    });
-	
 }


### PR DESCRIPTION
As of confirmation via bug report [9040](https://github.com/YoYoGames/GameMaker-Bugs/issues/9040), this is expected behavior and testing crashing syntax has been removed.