### PR TITLE
Audio group test fixes

### DIFF
--- a/projects/xUnit/scripts/ResourceAudioGroupsTestSuite/ResourceAudioGroupsTestSuite.gml
+++ b/projects/xUnit/scripts/ResourceAudioGroupsTestSuite/ResourceAudioGroupsTestSuite.gml
@@ -30,61 +30,54 @@ function ResourceAudioGroupsTestSuite() : TestSuite() constructor {
 	});
 
 	addFact("Default audio group test #2", function() {
-		
 		var loadProgress = audio_group_load_progress(audiogroup_default);
 		assert_equals(loadProgress, 100, "Default audiogroup's load progress should be at 100, as it should be loaded in by default");
-		
 	});
 	
 	addTestAsync("Audio groups loading test #1", objTestAsync, {
-		
 		ev_create: function() {
+            numFailed = 0;
 			
 			// Start loading audio groups
 			audioGroups = getAudioGroups();
+            numGroups = array_length(audioGroups);
 			
 			for (var i = 0; i < array_length(audioGroups); i++){
 				var group = audioGroups[i];
-				audio_group_load(group);
+				var loading = audio_group_load(group);
+                
+                if (!loading) {
+                    ++numFailed;
+                }
 			}
-			
 		},
 		
 		ev_step: function() {
-			
-			var loadedNum = 0;
-			
+            var numLoaded = 0;
+            
 			// Check if audio groups have been loaded
-			for (var i = 0; i < array_length(audioGroups); i++) {
-				
+			for (var i = 0; i < numGroups; i++) {
 				var group = audioGroups[i];
 				
 				if (audio_group_is_loaded(group)) {
-					loadedNum++;
-				}
-				
+					++numLoaded;
+                }
 			}
 			
-			show_debug_message("audio group numbers: " + string(array_length(audioGroups)));
-			show_debug_message("loaded groups : " + string(loadedNum));
-			
-			// If all audi groups have been loaded, end test
-			if (loadedNum == array_length(audioGroups)) {
-				
+			// If all audio groups have been loaded, end test
+			if (numLoaded + numFailed == numGroups) {
+                assert_equals(numFailed, 0, $"{numFailed} of {numGroups} audio groups failed to load");
+                
 				// Check that loading progress is at 100%
-				for (var i = 0; i < array_length(audioGroups); i++) {
-					
+				for (var i = 0; i < numGroups; i++) {
 					var group = audioGroups[i];
 					var loadProgress = audio_group_load_progress(group);
 					assert_equals(loadProgress, 100, "audio_group_load_progress should return 100% after loading in");
-					
 				}
 				
 				test_end();
 			}
-			
 		},
-		
 	});
 	
 	addFact("Sounds' associated audio group test #1", function() {
@@ -129,12 +122,10 @@ function ResourceAudioGroupsTestSuite() : TestSuite() constructor {
 	});
 	
 	addFact("Audio groups' assets test #1", function() {
-		
 		// Get audio groups that should be tested
 		var groupsToTest = getAudioGroups();
 		
 		for (var i = 0 ; i < array_length(groupsToTest); i++) {
-			
 			// Get current group
 			var group = groupsToTest[i];
 			
@@ -143,32 +134,22 @@ function ResourceAudioGroupsTestSuite() : TestSuite() constructor {
 			
 			// Test if assets are the correct ones
 			switch (group) {
-				
 				case audiogroup_default:
-					// Test just the frst sound in the default audio group
-					var sound = audioAssets[0];
-					assert_array_equals(sound, handle_testSound, "audio_group_get_assets should get the correct audio asset from audiogroup_default");
+					assert_true(array_contains(audioAssets, handleTestSound), "audio_group_get_assets should get the correct audio asset from audiogroup_default");
 					break;
-					
 				case audiogroup_MP3:
-					assert_array_equals(audioAssets, [snd_MP3], "audio_group_get_assets should get the correct audio assets from audiogroup_MP3");
+					assert_true(array_contains(audioAssets, snd_MP3), "audio_group_get_assets should get the correct audio assets from audiogroup_MP3");
 					break;
-				
 				case audiogroup_OGG:
-					assert_array_equals(audioAssets, [snd_OGG], "audio_group_get_assets should get the correct audio assets from audiogroup_OGG");
+					assert_true(array_contains(audioAssets, snd_OGG), "audio_group_get_assets should get the correct audio assets from audiogroup_OGG");
 					break;
-					
 				case audiogroup_WAV:
-					assert_array_equals(audioAssets, [snd_WAV], "audio_group_get_assets should get the correct audio assets from audiogroup_WAV");
+					assert_true(array_contains(audioAssets, snd_WAV), "audio_group_get_assets should get the correct audio assets from audiogroup_WAV");
 					break;
-					
 				default:
 					break;
-				
 			}
-			
 		}
-		
 	});
 
 	addFact("Audio group names test #1", function() {
@@ -242,7 +223,7 @@ function ResourceAudioGroupsTestSuite() : TestSuite() constructor {
 		
 		ev_create: function() {
 			
-			// Set gain of auio group to 1
+			// Set gain of audio group to 1
 			audio_group_set_gain(audiogroup_OGG, 1, 0);
 			
 			gain = audio_group_get_gain(audiogroup_OGG);
@@ -275,51 +256,49 @@ function ResourceAudioGroupsTestSuite() : TestSuite() constructor {
 	});
 	
 	addTestAsync("Audio group unloading test #1", objTestAsync, {
-		
 		ev_create: function() {
+            numFailed = 0;
 			
 			// Start unloading audio groups
 			audioGroups = getAudioGroups();
+            numGroups = array_length(audioGroups);
 			
 			for (var i = 0; i < array_length(audioGroups); i++){
 				var group = audioGroups[i];
-				audio_group_unload(group);
+				var unloading = audio_group_unload(group);
+                
+                if (!unloading) {
+                    ++numFailed;
+                }
 			}
-			
 		},
 		
 		ev_step: function() {
-			
-			var unloadedNum = 0;
-			
+            var numUnloaded = 0;
+            
 			// Check if audio groups have been unloaded
-			for (var i = 0; i < array_length(audioGroups); i++) {
-				
+			for (var i = 0; i < numGroups; i++) {
 				var group = audioGroups[i];
 				
 				if (!audio_group_is_loaded(group)) {
-					unloadedNum++;
+					numUnloaded++;
 				}
-				
 			}
 			
 			// If all audio groups have been unloaded, end test
-			if (unloadedNum == array_length(audioGroups)) {
-				
+			if (numUnloaded + numFailed == numGroups) {
+                assert_equals(numFailed, 0, $"{numFailed} of {numGroups} audio groups failed to unload");
+                
 				// Check that loading progress is at 0% for unloaded audiogroups
-				for (var i = 0; i < array_length(audioGroups); i++) {
-					
+				for (var i = 0; i < numGroups; i++) {
 					var group = audioGroups[i];
 					var loadProgress = audio_group_load_progress(group);
 					assert_equals(loadProgress, 0, "audio_group_load_progress should return 0% once the audio group has been unloaded");
-					
 				}
 				
 				test_end();
 			}
-			
 		},
-		
 	});
 	
 	config({

--- a/projects/xUnit/sounds/handle_testSound/handle_testSound.yy
+++ b/projects/xUnit/sounds/handle_testSound/handle_testSound.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"handle_testSound",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_default",
+    "path":"audiogroups/audiogroup_default",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_MP3/snd_MP3.yy
+++ b/projects/xUnit/sounds/snd_MP3/snd_MP3.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_MP3",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_MP3",
+    "path":"audiogroups/audiogroup_MP3",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_OGG/snd_OGG.yy
+++ b/projects/xUnit/sounds/snd_OGG/snd_OGG.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_OGG",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_OGG",
+    "path":"audiogroups/audiogroup_OGG",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_WAV/snd_WAV.yy
+++ b/projects/xUnit/sounds/snd_WAV/snd_WAV.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_WAV",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_WAV",
+    "path":"audiogroups/audiogroup_WAV",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_coinpickup_MP3/snd_coinpickup_MP3.yy
+++ b/projects/xUnit/sounds/snd_coinpickup_MP3/snd_coinpickup_MP3.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_coinpickup_MP3",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_MP3",
+    "path":"audiogroups/audiogroup_MP3",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_coinpickup_OGG/snd_coinpickup_OGG.yy
+++ b/projects/xUnit/sounds/snd_coinpickup_OGG/snd_coinpickup_OGG.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_coinpickup_OGG",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_OGG",
+    "path":"audiogroups/audiogroup_OGG",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_coinpickup_WAV/snd_coinpickup_WAV.yy
+++ b/projects/xUnit/sounds/snd_coinpickup_WAV/snd_coinpickup_WAV.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_coinpickup_WAV",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_WAV",
+    "path":"audiogroups/audiogroup_WAV",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_compressed/snd_compressed.yy
+++ b/projects/xUnit/sounds/snd_compressed/snd_compressed.yy
@@ -1,12 +1,15 @@
 {
   "$GMSound":"",
   "%Name":"snd_compressed",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_default",
+    "path":"audiogroups/audiogroup_default",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":1,
   "conversionMode":0,
-  "duration":26.592,
+  "duration":26.56365,
   "name":"snd_compressed",
   "parent":{
     "name":"sounds",

--- a/projects/xUnit/sounds/snd_jump_MP3/snd_jump_MP3.yy
+++ b/projects/xUnit/sounds/snd_jump_MP3/snd_jump_MP3.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_jump_MP3",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_MP3",
+    "path":"audiogroups/audiogroup_MP3",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_jump_OGG/snd_jump_OGG.yy
+++ b/projects/xUnit/sounds/snd_jump_OGG/snd_jump_OGG.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_jump_OGG",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_OGG",
+    "path":"audiogroups/audiogroup_OGG",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,

--- a/projects/xUnit/sounds/snd_jump_WAV/snd_jump_WAV.yy
+++ b/projects/xUnit/sounds/snd_jump_WAV/snd_jump_WAV.yy
@@ -1,7 +1,10 @@
 {
   "$GMSound":"",
   "%Name":"snd_jump_WAV",
-  "audioGroupId":null,
+  "audioGroupId":{
+    "name":"audiogroup_WAV",
+    "path":"audiogroups/audiogroup_WAV",
+  },
   "bitDepth":1,
   "bitRate":128,
   "compression":0,


### PR DESCRIPTION
[GMB-9284](https://github.com/YoYoGames/GameMaker-Bugs/issues/9284) + [GMB-9285](https://github.com/YoYoGames/GameMaker-Bugs/issues/9285) + [GMB-9286](https://github.com/YoYoGames/GameMaker-Bugs/issues/9286) + [GMB-9320](https://github.com/YoYoGames/GameMaker-Bugs/issues/9320)
- Fixed the group assignments of audio assets in the project, which had all managed to end up in `audiogroup_default`.
- Added handling for audio groups potentially failing to load in `"Audio groups loading test #1"`.
- Added handling for audio groups potentially failing to unload in `"Audio group unloading test #1"`.
- Changed test `"Audio groups' assets test #1"` to check that the returned array contains the specified asset.