### PR TITLE
Fix audio group assignments

### DIFF
--- a/projects/xUnit/sounds/snd_coinpickup_MP3/snd_coinpickup_MP3.yy
+++ b/projects/xUnit/sounds/snd_coinpickup_MP3/snd_coinpickup_MP3.yy
@@ -2,8 +2,8 @@
   "$GMSound":"",
   "%Name":"snd_coinpickup_MP3",
   "audioGroupId":{
-    "name":"audiogroup_MP3",
-    "path":"audiogroups/audiogroup_MP3",
+    "name":"audiogroup_default",
+    "path":"audiogroups/audiogroup_default",
   },
   "bitDepth":1,
   "bitRate":128,

--- a/projects/xUnit/sounds/snd_coinpickup_OGG/snd_coinpickup_OGG.yy
+++ b/projects/xUnit/sounds/snd_coinpickup_OGG/snd_coinpickup_OGG.yy
@@ -2,8 +2,8 @@
   "$GMSound":"",
   "%Name":"snd_coinpickup_OGG",
   "audioGroupId":{
-    "name":"audiogroup_OGG",
-    "path":"audiogroups/audiogroup_OGG",
+    "name":"audiogroup_default",
+    "path":"audiogroups/audiogroup_default",
   },
   "bitDepth":1,
   "bitRate":128,

--- a/projects/xUnit/sounds/snd_coinpickup_WAV/snd_coinpickup_WAV.yy
+++ b/projects/xUnit/sounds/snd_coinpickup_WAV/snd_coinpickup_WAV.yy
@@ -2,8 +2,8 @@
   "$GMSound":"",
   "%Name":"snd_coinpickup_WAV",
   "audioGroupId":{
-    "name":"audiogroup_WAV",
-    "path":"audiogroups/audiogroup_WAV",
+    "name":"audiogroup_default",
+    "path":"audiogroups/audiogroup_default",
   },
   "bitDepth":1,
   "bitRate":128,

--- a/projects/xUnit/sounds/snd_jump_MP3/snd_jump_MP3.yy
+++ b/projects/xUnit/sounds/snd_jump_MP3/snd_jump_MP3.yy
@@ -2,8 +2,8 @@
   "$GMSound":"",
   "%Name":"snd_jump_MP3",
   "audioGroupId":{
-    "name":"audiogroup_MP3",
-    "path":"audiogroups/audiogroup_MP3",
+    "name":"audiogroup_default",
+    "path":"audiogroups/audiogroup_default",
   },
   "bitDepth":1,
   "bitRate":128,

--- a/projects/xUnit/sounds/snd_jump_OGG/snd_jump_OGG.yy
+++ b/projects/xUnit/sounds/snd_jump_OGG/snd_jump_OGG.yy
@@ -2,8 +2,8 @@
   "$GMSound":"",
   "%Name":"snd_jump_OGG",
   "audioGroupId":{
-    "name":"audiogroup_OGG",
-    "path":"audiogroups/audiogroup_OGG",
+    "name":"audiogroup_default",
+    "path":"audiogroups/audiogroup_default",
   },
   "bitDepth":1,
   "bitRate":128,

--- a/projects/xUnit/sounds/snd_jump_WAV/snd_jump_WAV.yy
+++ b/projects/xUnit/sounds/snd_jump_WAV/snd_jump_WAV.yy
@@ -2,8 +2,8 @@
   "$GMSound":"",
   "%Name":"snd_jump_WAV",
   "audioGroupId":{
-    "name":"audiogroup_WAV",
-    "path":"audiogroups/audiogroup_WAV",
+    "name":"audiogroup_default",
+    "path":"audiogroups/audiogroup_default",
   },
   "bitDepth":1,
   "bitRate":128,


### PR DESCRIPTION
[GMB-9284](https://github.com/YoYoGames/GameMaker-Bugs/issues/9284) + [GMB-9285](https://github.com/YoYoGames/GameMaker-Bugs/issues/9285) + [GMB-9286](https://github.com/YoYoGames/GameMaker-Bugs/issues/9286) + [GMB-9320](https://github.com/YoYoGames/GameMaker-Bugs/issues/9320)
- Fixes a mistake in https://github.com/YoYoGames/GM-TestFramework/pull/211 where too many audio assets were moved out of `audiogroup_default`.