### PR TITLE
XML report improvements

### DIFF
--- a/classes/model/TestFrameworkResult.py
+++ b/classes/model/TestFrameworkResult.py
@@ -11,6 +11,7 @@ class TestFrameworkResult(BaseModel):
     name: str = ""
     timestamp: float = 0
     testsuites: Optional[list[TestSuiteResult]] = []
+    properties: Optional[dict[str, str]] = {}
 
     def get_duration(self):
         return sum(testsuite.get_duration() for testsuite in self.testsuites)
@@ -55,12 +56,20 @@ class TestFrameworkResult(BaseModel):
         element.set("failures", str(self.get_failure_count()))
         element.set("errors", str(self.get_error_count()))
         element.set("skipped", str(self.get_skipped_count()))
-        element.set("assertions", str(self.get_assertion_count()))
         element.set("time", str(self.get_duration() / 1000000))
         element.set("timestamp", self.get_iso_timestamp())
 
+        if self.properties:
+            properties_element = ElementTree.Element('properties')
+            for key, value in self.properties.items():
+                property_element = ElementTree.Element('property')
+                property_element.set("name", key)
+                property_element.set("value", value)
+                properties_element.append(property_element)
+            element.append(properties_element)
+
         for testsuite in self.testsuites:
-            element.append(testsuite.to_xml(self.name))
+            element.append(testsuite.to_xml())
         return element
     
     def to_dict(self) -> dict:

--- a/classes/model/TestResult.py
+++ b/classes/model/TestResult.py
@@ -3,8 +3,6 @@ import xml.etree.ElementTree as ElementTree
 
 from pydantic import BaseModel
 
-from utils import data_utils
-
 class TestResult(BaseModel):
     name: str = ""
     result: str = ""
@@ -25,13 +23,10 @@ class TestResult(BaseModel):
     def was_skipped(self):
         return self.result.lower() == "skipped"
     
-    def to_xml(self) -> ElementTree.Element:
+    def to_xml(self, classname: str = "") -> ElementTree.Element:
         element = ElementTree.Element('testcase')
         element.set("name", self.name)
-
-        # Extract classname from test name (part before first hyphen, if any)
-        classname = self.name.split('-')[0] if '-' in self.name else self.name
-        element.set("classname", classname)
+        element.set("classname", classname if classname else self.name)
 
         element.set("time", str(self.duration / 1000000))
         element.set("status", "run")
@@ -40,12 +35,25 @@ class TestResult(BaseModel):
             exception_element = ElementTree.Element('error')
             exception_element.set("type", "ExceptionThrownError")
 
-            # Handle both string and dict exceptions
+            # Format exception as human-readable text
             if isinstance(exception, dict):
-                exception_element.set("message", str(exception.get('message', 'Exception occurred')))
-                exception_element.text = data_utils.json_stringify(exception)
+                lines = []
+
+                if exception.get('message'):
+                    lines.append(f"Message: {exception['message']}")
+
+                if exception.get('description'):
+                    lines.append(f"Description: {exception['description']}")
+
+                if exception.get('stack'):
+                    lines.append("Callstack:")
+                    stack_lines = exception['stack'].strip().split('\n')
+                    for stack_line in stack_lines:
+                        if stack_line.strip():
+                            lines.append(f"  {stack_line.strip()}")
+
+                exception_element.text = '\n'.join(lines) if lines else str(exception)
             else:
-                exception_element.set("message", str(exception))
                 exception_element.text = str(exception)
 
             element.append(exception_element)
@@ -54,17 +62,32 @@ class TestResult(BaseModel):
             error_element = ElementTree.Element('failure')
             error_element.set("type", "AssertionError")
 
-            # Create a meaningful message from error details
-            message_parts = []
+            # Create a human-friendly formatted message
             if isinstance(error, dict):
+                lines = []
+
+                if error.get('title'):
+                    lines.append(f"Title: {error['title']}")
+
                 if error.get('description'):
-                    message_parts.append(error['description'])
-                if error.get('expected') is not None and error.get('actual') is not None:
-                    message_parts.append(f"Expected: {error['expected']}, Actual: {error['actual']}")
-                error_element.set("message", ' - '.join(message_parts) if message_parts else "Assertion failed")
-                error_element.text = data_utils.json_stringify(error)
+                    lines.append(f"Description: {error['description']}")
+
+                if error.get('expected') is not None:
+                    lines.append(f"Expected value: {error['expected']}")
+
+                if error.get('actual') is not None:
+                    lines.append(f"Got value: {error['actual']}")
+
+                if error.get('stack'):
+                    lines.append("Callstack:")
+                    # Split stack trace by newlines and format each line with indentation
+                    stack_lines = error['stack'].strip().split('\n')
+                    for stack_line in stack_lines:
+                        if stack_line.strip():
+                            lines.append(f"  {stack_line.strip()}")
+
+                error_element.text = '\n'.join(lines) if lines else "Assertion failed"
             else:
-                error_element.set("message", str(error))
                 error_element.text = str(error)
 
             element.append(error_element)
@@ -72,7 +95,7 @@ class TestResult(BaseModel):
         if self.did_expire():
             error_element = ElementTree.Element('failure')
             error_element.set("type", "ExpiredError")
-            error_element.set("message", "Test execution expired")
+            error_element.text = "Test execution expired"
             element.append(error_element)
 
         if self.was_skipped():

--- a/classes/model/TestResult.py
+++ b/classes/model/TestResult.py
@@ -28,24 +28,51 @@ class TestResult(BaseModel):
     def to_xml(self) -> ElementTree.Element:
         element = ElementTree.Element('testcase')
         element.set("name", self.name)
-        element.set("assertions", str(self.assertions))
+
+        # Extract classname from test name (part before first hyphen, if any)
+        classname = self.name.split('-')[0] if '-' in self.name else self.name
+        element.set("classname", classname)
+
         element.set("time", str(self.duration / 1000000))
-        
+        element.set("status", "run")
+
         for exception in self.exceptions:
             exception_element = ElementTree.Element('error')
             exception_element.set("type", "ExceptionThrownError")
-            exception_element.text = data_utils.json_stringify(exception)
+
+            # Handle both string and dict exceptions
+            if isinstance(exception, dict):
+                exception_element.set("message", str(exception.get('message', 'Exception occurred')))
+                exception_element.text = data_utils.json_stringify(exception)
+            else:
+                exception_element.set("message", str(exception))
+                exception_element.text = str(exception)
+
             element.append(exception_element)
-        
+
         for error in self.errors:
             error_element = ElementTree.Element('failure')
             error_element.set("type", "AssertionError")
-            error_element.text = data_utils.json_stringify(error)
+
+            # Create a meaningful message from error details
+            message_parts = []
+            if isinstance(error, dict):
+                if error.get('description'):
+                    message_parts.append(error['description'])
+                if error.get('expected') is not None and error.get('actual') is not None:
+                    message_parts.append(f"Expected: {error['expected']}, Actual: {error['actual']}")
+                error_element.set("message", ' - '.join(message_parts) if message_parts else "Assertion failed")
+                error_element.text = data_utils.json_stringify(error)
+            else:
+                error_element.set("message", str(error))
+                error_element.text = str(error)
+
             element.append(error_element)
-        
+
         if self.did_expire():
             error_element = ElementTree.Element('failure')
             error_element.set("type", "ExpiredError")
+            error_element.set("message", "Test execution expired")
             element.append(error_element)
 
         if self.was_skipped():
@@ -70,17 +97,17 @@ class TestResult(BaseModel):
             'name': self.name,
             **({'errors': [
                     {
-                        'expected': error.get('expected'),
-                        'actual': error.get('actual'),
-                        'description': error.get('description')
+                        'expected': error.get('expected') if isinstance(error, dict) else None,
+                        'actual': error.get('actual') if isinstance(error, dict) else str(error),
+                        'description': error.get('description') if isinstance(error, dict) else None
                     } for error in self.errors
                 ]} if self.errors else {})
         }
-        
+
         if self.exceptions:
             summary['exceptions'] = {
                 'count': len(self.exceptions),
                 'first': self.exceptions[0]
             }
-        
+
         return summary

--- a/classes/model/TestSuiteResult.py
+++ b/classes/model/TestSuiteResult.py
@@ -44,7 +44,7 @@ class TestSuiteResult(BaseModel):
         element.set("timestamp", self.get_iso_timestamp())
 
         for test in self.tests:
-            element.append(test.to_xml())
+            element.append(test.to_xml(classname=self.name))
         return element
     
     def to_dict(self) -> dict:

--- a/classes/model/TestSuiteResult.py
+++ b/classes/model/TestSuiteResult.py
@@ -33,14 +33,13 @@ class TestSuiteResult(BaseModel):
         iso_format = dt.isoformat()
         return iso_format
 
-    def to_xml(self, suffix: str = "") -> ElementTree.Element:
+    def to_xml(self) -> ElementTree.Element:
         element = ElementTree.Element('testsuite')
-        element.set("name", f'{self.name}:{suffix}')
+        element.set("name", self.name)
         element.set("tests", str(self.get_test_count()))
         element.set("failures", str(self.get_failure_count()))
         element.set("errors", str(self.get_error_count()))
         element.set("skipped", str(self.get_skipped_count()))
-        element.set("assertions", str(self.get_assertion_count()))
         element.set("time", str(self.get_duration() / 1000000))
         element.set("timestamp", self.get_iso_timestamp())
 

--- a/classes/server/RemoteControlServer.py
+++ b/classes/server/RemoteControlServer.py
@@ -32,7 +32,7 @@ class RemoteControlServer:
     def __init__(self, mode: ExecutionMode, timeout: int = 1, run_name = 'xUnit'):
         """
         Initialize the RemoteControlServer with the given mode.
-        
+
         Args:
             mode (Mode): The mode of operation, either AUTOMATIC or MANUAL.
         """
@@ -40,13 +40,21 @@ class RemoteControlServer:
         self.timeout = timeout
         self.run_name = run_name
 
+        # Parse platform metadata from run_name (format: name:platform:config)
+        self.properties = {}
+        run_name_parts = run_name.split(':')
+        if len(run_name_parts) >= 2:
+            self.properties['platform'] = run_name_parts[1]
+        if len(run_name_parts) >= 3:
+            self.properties['config'] = run_name_parts[2]
+
         self.tests = []
         self.current_test_index = 0
         self.state = State.WAITING
         self.stop_event = asyncio.Event()
         self.reboot_event = asyncio.Event()
         self.strategy = self._select_strategy()
-        
+
         self.framework_result: TestFrameworkResult = None
         self.suite_results: dict[str, TestSuiteResult] = {}
 
@@ -90,7 +98,7 @@ class RemoteControlServer:
     def _add_test_result(self, result_data: dict, suite: str, timestamp: float):
         # Initialize framework result if not already set
         if not self.framework_result:
-            self.framework_result = TestFrameworkResult(name=self.run_name, timestamp=timestamp)
+            self.framework_result = TestFrameworkResult(name=self.run_name, timestamp=timestamp, properties=self.properties)
             LOGGER.info(f"Initialized framework result: {self.framework_result.name} at {timestamp}")
 
         # Initialize suite result or switch to a new suite if necessary

--- a/classes/server/TestFrameworkServer.py
+++ b/classes/server/TestFrameworkServer.py
@@ -186,6 +186,14 @@ class TestFrameworkServer:
             run_name: str = body["data"]["run_name"]
             results: list[dict] = body["data"]["results"]
 
+            # Parse platform metadata from run_name (format: name:platform:config)
+            properties = {}
+            run_name_parts = run_name.split(':')
+            if len(run_name_parts) >= 2:
+                properties['platform'] = run_name_parts[1]
+            if len(run_name_parts) >= 3:
+                properties['config'] = run_name_parts[2]
+
             framework_result: Optional[TestFrameworkResult] = None
             suite_results: dict[str, TestSuiteResult] = {}
 
@@ -198,7 +206,7 @@ class TestFrameworkServer:
 
                 # Initialize framework result if not already set
                 if not framework_result:
-                    framework_result = TestFrameworkResult(name=run_name, timestamp=timestamp)
+                    framework_result = TestFrameworkResult(name=run_name, timestamp=timestamp, properties=properties)
                     LOGGER.debug(f"Initialized framework result: {framework_result.name} at {timestamp}")
 
                 # Initialize suite result or switch to a new suite if necessary

--- a/launcher.py
+++ b/launcher.py
@@ -129,9 +129,9 @@ def check_xml_json_pairs_and_failures(directory):
             full_summary[key] = summary
             if summary.get('status') == 'failed':
                 failed = True
-    
-    LOGGER.info(f"Printing summary:\n{data_utils.json_stringify(full_summary)}")
-        
+
+    LOGGER.debug(f"Test summary:\n{data_utils.json_stringify(full_summary)}")
+
     return failed
 
 # Execution


### PR DESCRIPTION
- Emit standard JUnit XML without special handling
  - Until now, we placed the `run_name` in the XML as a suffix to runs. This was essential with the old testing rig(s). We no longer need this: if anything, it makes parsing on the result ingestion side more complicated
- Make XML failure message human-readable
  Before:
  ```
  {
    "title": "Asserted value to be true",
    "description": "file_copy ( oldName, newName ), failed to copy (old file doesn't exist)",
    "actual": "false",
    "expected": "null",
    "stack": "C:\\actions-runner\\_work\\GMRT\\GMRT\\testframework\\projects\\xUnit\\scripts\\BasicFileTestSuite\\BasicFileTestSuite.gml (299): gm_aot_MOD_scripts_x2F_BasicFileTestSuite_x2F_BasicFileTestSuite_FUNC__funcexpr_x40_anon_x40_10909BasicFileTestSuite__x24_BasicFileTestSuite\n"
  }
  ```
  After:
  ```
  Title: Asserted value to be true
  Description: file_copy ( oldName, newName ), failed to copy (old file doesn't exist)
  Expected value: null
  Got value: false
  Callstack:
    C:\source\GM-TestFramework\projects\xUnit\scripts\BasicFileTestSuite\BasicFileTestSuite.gml (299): gm_aot_MOD_scripts_x2F_BasicFileTestSuite_x2F_BasicFileTestSuite_FUNC__funcexpr_x40_anon_x40_10363BasicFileTestSuite__x24_BasicFileTestSuite
  ```