### PR TITLE
[json_stringify] Modifying test to account for differences between GM…

### DIFF
--- a/projects/xUnit/scripts/BasicJsonTestSuite/BasicJsonTestSuite.gml
+++ b/projects/xUnit/scripts/BasicJsonTestSuite/BasicJsonTestSuite.gml
@@ -389,11 +389,23 @@ function BasicJsonTestSuite() : TestSuite() constructor {
 		
 		_output = json_parse(_jsonStr);
 		
-		var _test = {
-			version: 2,
-			myArray: "array",
-			myFunction: "func",
-		}
+        if(runtime_gmrt())
+        {
+        
+     		var _test = {
+     			version: 2,
+     			myArray: "array",
+     			myFunction: "func",
+     		}
+        }
+        else {
+            //In current runtime 2 could be a script index so is_callable returns true
+        	var _test = {
+     			version: "func",
+     			myArray: "array",
+     			myFunction: "func",
+     		}
+        }
 		
 		assert_struct_equals(_test, _output, "json_stringify ( struct:local, ..., replacer ), use custom replace funnction (structs are not equal)")			
 	});


### PR DESCRIPTION
…RT and current runtime

numbers are callable in current runtime as they may be script indices (legacy behaviour) Note, another part of this fix is being handled in runtime develop branch

https://github.com/YoYoGames/GameMaker-Bugs/issues/14335