### PR TITLE
Revert IDE resave noise from #354

### DIFF
--- a/projects/xUnit/options/switch/options_switch.yy
+++ b/projects/xUnit/options/switch/options_switch.yy
@@ -1,5 +1,5 @@
 {
-  "$GMSwitchOptions":"v1",
+  "$GMSwitchOptions":"",
   "%Name":"Switch",
   "name":"Switch",
   "option_switch_allow_debug_output":false,
@@ -7,7 +7,6 @@
   "option_switch_enable_fileaccess_checking":true,
   "option_switch_enable_nex_libraries":false,
   "option_switch_enable_npln_libraries":false,
-  "option_switch_enable_touchscreen":true,
   "option_switch_gfx_mem_mb":256,
   "option_switch_interpolate_pixels":true,
   "option_switch_project_nmeta":"${options_dir}/switch/application.nmeta",

--- a/projects/xUnit/options/switch2/options_switch2.yy
+++ b/projects/xUnit/options/switch2/options_switch2.yy
@@ -1,5 +1,5 @@
 {
-  "$GMSwitch2Options":"v1",
+  "$GMSwitch2Options":"",
   "%Name":"Switch2",
   "name":"Switch2",
   "option_switch2_allow_debug_output":false,
@@ -7,7 +7,6 @@
   "option_switch2_enable_fileaccess_checking":true,
   "option_switch2_enable_nex_libraries":false,
   "option_switch2_enable_npln_libraries":false,
-  "option_switch2_enable_touchscreen":true,
   "option_switch2_gfx_mem_mb":256,
   "option_switch2_interpolate_pixels":true,
   "option_switch2_project_nmeta":"${options_dir}/switch2/application.nmeta",

--- a/projects/xUnit/options/windows/options_windows.yy
+++ b/projects/xUnit/options/windows/options_windows.yy
@@ -1,5 +1,5 @@
 {
-  "$GMWindowsOptions":"v2",
+  "$GMWindowsOptions":"v1",
   "%Name":"Windows",
   "name":"Windows",
   "option_windows_allow_fullscreen_switching":false,
@@ -29,7 +29,6 @@
   "option_windows_start_fullscreen":false,
   "option_windows_steam_use_alternative_launcher":false,
   "option_windows_texture_page":"2048x2048",
-  "option_windows_use_raw_mouse":false,
   "option_windows_use_splash":false,
   "option_windows_version":"1.0.0.0",
   "option_windows_vsync":false,

--- a/projects/xUnit/xUnit.yyp
+++ b/projects/xUnit/xUnit.yyp
@@ -74,6 +74,7 @@
     {"link":"io.gamemaker.gm_filter_large_blur-1.0.0","name":"io.gamemaker.gm_filter_large_blur-1.0.0","path":"io.gamemaker.gm_filter_large_blur-1.0.0.yyp",},
   ],
   "IncludedFiles":[
+    {"$GMIncludedFile":"","%Name":"config.json","CopyToMask":-1,"filePath":"datafiles","name":"config.json","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"drawTilemapTestExpected.png","CopyToMask":-1,"filePath":"datafiles","name":"drawTilemapTestExpected.png","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"drawTilemapTestExpectedBuffer","CopyToMask":-1,"filePath":"datafiles","name":"drawTilemapTestExpectedBuffer","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"drawTileTestExpected.png","CopyToMask":-1,"filePath":"datafiles","name":"drawTileTestExpected.png","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
@@ -212,7 +213,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2026.100.0.1135",
+    "IDEVersion":"2024.1400.2.934",
   },
   "name":"xUnit",
   "resources":[


### PR DESCRIPTION
Fixes the nightly `testframework` failure (GMRT #6522, #6523).

#354 was saved from a 2026.100 IDE, which bumped resource format markers that GMRT's pinned
CoreResources (`2024.1400.0.58`) cannot read: `$GMWindowsOptions` v1 -> v2, `$GMSwitchOptions` and
`$GMSwitch2Options` "" -> v1. GMRT then asks ProjectTool to downgrade the project, but the test runner
never passes `--projecttool`, so the load dies with `Cannot start process because a file name has not
been provided` and the run publishes no results.

The same resave also dropped `config.json` from `IncludedFiles`, since that file is generated at test
time and was not on disk when the project was opened. `frameworkSetup.gml` loads it via
`config_manager_load`.

Reverts both, plus the cosmetic `IDEVersion` stamp. The script renames #354 was actually for are
untouched.

Verified locally against a Debug `gmrtd.exe`: the load crash is gone and the project loads. Note that
xUnit still fails later on shader compilation (`gmslangc`, `ambiguous reference to 'i'`), which is a
separate pre-existing problem this does not address - CI never reached that stage before.
